### PR TITLE
[G2M] take float into account for sorting

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -9,7 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `Dropzone` component added
 
 ### Fixed
-- `DataTable` Render No columns selected as the placeholder message  with empty dataset.
+- `DataTable` Render No columns selected as the placeholder message with empty dataset.
+- `DataTable` unable to sort on float value
 
 ### Changed
 - *[Breaking Change]* `peerDependencies` updated with React `^16.8` for utilization of hooks.

--- a/src/utils/sort.js
+++ b/src/utils/sort.js
@@ -26,13 +26,13 @@ export const sort = (type, direction) => {
   case 'basic':
   default:
     return (a, b) => {
-      if (!parseInt(a) && !parseInt(b)) {
+      if (!Number(a) && !Number(b)) {
         return 0
       }
-      if (!parseInt(a)) {
+      if (!Number(a)) {
         return -dirFactor
       }
-      if (!parseInt(b)) {
+      if (!Number(b)) {
         return dirFactor
       }
       return dirFactor * (a - b)
@@ -50,7 +50,7 @@ export const getDefaultSortType = (data, key) => {
     return null
   }
 
-  if (Number.isInteger(value)) {
+  if (typeof value === 'number') {
     return 'basic'
   } else if (Number.isInteger(Date.parse(value))) {
     return 'date'

--- a/src/utils/sort.js
+++ b/src/utils/sort.js
@@ -26,13 +26,13 @@ export const sort = (type, direction) => {
   case 'basic':
   default:
     return (a, b) => {
-      if (!Number(a) && !Number(b)) {
+      if (isNaN(Number(a)) && isNaN(Number(b))) {
         return 0
       }
-      if (!Number(a)) {
+      if (isNaN(Number(a))) {
         return -dirFactor
       }
-      if (!Number(b)) {
+      if (isNaN(Number(b))) {
         return dirFactor
       }
       return dirFactor * (a - b)


### PR DESCRIPTION
current float sorting is broken because:
* float is not detected as number because using `Number.isInteger` to check
* even if `sortType` is specified as `basic`, sorting is broken because using `parseInt` on float